### PR TITLE
Added articles, new groupings, dates

### DIFF
--- a/writeups.md
+++ b/writeups.md
@@ -1,22 +1,38 @@
-# List of Writeups (Not in any specific order)
+# List of Contestant Writeups (Not in any specific order)
 
-Author | Link
-------|------------
-TraceLabs | [In Depth Blog by DC27 Missing CTF Winners on OSINT Techniques for Missing Persons: (11 pages)](https://medium.com/@tracelabs/tales-from-defcon-27s-missing-persons-ctf-winners-team-w00kies-acea2f12d07d)
-Robert Sell | [BSides Portland 2018 Event Debrief](https://www.tracelabs.org/2018/10/bsides-portland-2018-event-debrief)
-Robert Sell | [The World’s First OSINT CTF for Missing Persons](https://www.tracelabs.org/2018/07/the-worlds-first-osint-ctf-for-missing-persons)
-ex0xploit | [Cybrary - OSINT Investigations](https://www.cybrary.it/blog/0p3n/osint-investigations/)
-Nerdy & The Brain | [My OSINT CTF Journey - Part 1](https://nerdyandthebrain.com/f/my-osint-ctf-journey---part-1)
-Nerdy & The Brain | [My OSINT CTF Journey - Part 2](https://nerdyandthebrain.com/f/my-osint-ctf-journey---part-2)
-Nerdy & The Brain | [My OSINT CTF Journey - Part 3](https://nerdyandthebrain.com/f/my-osint-ctf-journey---part-3)
-RagSec | [Trace Labs Global Missing Persons CTF – July 2019](https://ragsec.co.uk/trace-labs-global-missing-persons-ctf-july-2019)
-AzuleOnyx | [Trace Labs CTF Judge vs Member](https://cyberfenixtech.blogspot.com/2019/10/trace-labs-ctf-judge-vs-member.html)
-wondersmith_rae | [Finding Missing People with Trace Labs CTF](https://medium.com/@raebaker/finding-missing-people-with-tracelabs-ctf-d5617c7cd659)
-AaronCTI | [Trace Labs Missing Persons CTF IV — Review & Summary](https://www.aaroncti.com/trace-labs-iv/)
-Micah Hoffman | [#OSINTforGood: Using Open-Source Intelligence to Solve Real-World Problems](https://www.sans.org/blog/osintforgood-using-open-source-intelligence-to-solve-real-world-problems/)
-Charlie Rivera (th3cyb3rguy) | [I’ll Be The Judge Of That](https://th3cyb3rguy.com/2020/08/09/ill-be-the-judge-of-that/)
-Amanda Szampias | [Tracelabs Global Missings Person CTF: Defcon Edition Review](http://amandaszampias.blogspot.com/2020/08/tracelabs-global-missings-person-ctf.html)
-Brigada OSINT | [Osint Search Party 8-2020](https://www.brigadaosint.com/osint-search-party-8-2020/)
-AaronCTI | [Trace Labs CTF August 2020 – Approach & Methodology](https://www.aaroncti.com/trace-labs-august-2020/)
-Levitannin | [From the Judge’s Seat: A TraceLabs CTF Recount](https://medium.com/@levitannin/from-the-judges-seat-a-tracelabs-ctf-recount-49b0d1c3c89a?sk=dd8e0e26c7daa2d220c14d261ff01362)
-SecBoyUK | [5th Place in TraceLab/SANS OSINT Search Party CTF](https://secboyuk.wordpress.com/2020/08/23/5th-place-in-tracelab-sans-osint-ctf/)
+Author | Date | Link
+------|-------|------------
+TraceLabs | Sept 2019 | [In Depth Blog by DC27 Missing CTF Winners on OSINT Techniques for Missing Persons: (11 pages)](https://medium.com/@tracelabs/tales-from-defcon-27s-missing-persons-ctf-winners-team-w00kies-acea2f12d07d)
+Robert Sell | Oct 2018 | [BSides Portland 2018 Event Debrief](https://www.tracelabs.org/2018/10/bsides-portland-2018-event-debrief)
+Robert Sell | July 2018 | [The World’s First OSINT CTF for Missing Persons](https://www.tracelabs.org/2018/07/the-worlds-first-osint-ctf-for-missing-persons)
+Nerdy & The Brain | Jan 2020 | [My OSINT CTF Journey - Part 1](https://nerdyandthebrain.com/f/my-osint-ctf-journey---part-1)
+Nerdy & The Brain | Jan 2020 | [My OSINT CTF Journey - Part 2](https://nerdyandthebrain.com/f/my-osint-ctf-journey---part-2)
+Nerdy & The Brain | Feb 2020 | [My OSINT CTF Journey - Part 3](https://nerdyandthebrain.com/f/my-osint-ctf-journey---part-3)
+RagSec | July 2019 | [Trace Labs Global Missing Persons CTF – July 2019](https://ragsec.co.uk/trace-labs-global-missing-persons-ctf-july-2019)
+wondersmith_rae | July 2019 | [Finding Missing People with Trace Labs CTF](https://medium.com/@raebaker/finding-missing-people-with-tracelabs-ctf-d5617c7cd659)
+AaronCTI | Aug 2020 | [Trace Labs Missing Persons CTF IV — Review & Summary](https://www.aaroncti.com/trace-labs-iv/)
+Micah Hoffman | Jan 2020 | [#OSINTforGood: Using Open-Source Intelligence to Solve Real-World Problems](https://www.sans.org/blog/osintforgood-using-open-source-intelligence-to-solve-real-world-problems/)
+Amanda Szampias | July 2020 | [Trace Labs Global Missing Persons CTF V](https://amandaszampias.blogspot.com/2020/07/trace-labs-global-missing-persons-ctf-v.html)
+Amanda Szampias | Aug 2020 | [Tracelabs Global Missings Person CTF: Defcon Edition Review](http://amandaszampias.blogspot.com/2020/08/tracelabs-global-missings-person-ctf.html)
+Brigada OSINT | Aug 2020 | [Osint Search Party 8-2020](https://www.brigadaosint.com/osint-search-party-8-2020/)
+AaronCTI | Aug 2020 | [Trace Labs CTF August 2020 – Approach & Methodology](https://www.aaroncti.com/trace-labs-august-2020/)
+SecBoyUK | Aug 2020 | [5th Place in TraceLab/SANS OSINT Search Party CTF](https://secboyuk.wordpress.com/2020/08/23/5th-place-in-tracelab-sans-osint-ctf/)
+Shandyman | Mar 2020 | [On A Mission – A TraceLabs CTF Missing Persons Writeup](https://shandyman.online/blog/on-a-mission-a-tracelabs-ctf-missing-persons-writeup/)
+Francois Mouton | July 2020 | [Noroff University College excels at Trace Labs CTF](https://www.linkedin.com/pulse/noroff-university-college-excels-trace-labs-ctf-francois-mouton/)
+Hxc | July 2020 | [A Beginners write up to Trace Labs 2020 OSINT CTF for missing persons](https://medium.com/@hxc/a-beginners-write-up-to-trace-labs-2020-osint-ctf-for-missing-persons-624077c3c9cb)
+Steve Adams | July 2020 | [A guide to participating in a Trace Labs Global OSINT Search Party CTF](https://www.intelligencewithsteve.com/post/a-guide-to-participating-in-a-trace-labs-global-osint-search-party-ctf)
+
+
+# List of Judge Writeups (Not in any specific order)
+Author | Date | Link
+------|-------|------------
+AzuleOnyx | Oct 2019 | [Trace Labs CTF Judge vs Member](https://cyberfenixtech.blogspot.com/2019/10/trace-labs-ctf-judge-vs-member.html)
+Charlie Rivera (th3cyb3rguy) | Aug 2020 | [I’ll Be The Judge Of That](https://th3cyb3rguy.com/2020/08/09/ill-be-the-judge-of-that/)
+Levitannin | Aug 2020 | [From the Judge’s Seat: A TraceLabs CTF Recount](https://medium.com/@levitannin/from-the-judges-seat-a-tracelabs-ctf-recount-49b0d1c3c89a?sk=dd8e0e26c7daa2d220c14d261ff01362)
+
+
+# List of OSINT Writeups w/ TraceLabs CTF not mentioned (Not in any specific order)
+Author | Date | Link
+------|-------|------------
+ex0xploit | Dec 2016 | [Cybrary - OSINT Investigations](https://www.cybrary.it/blog/0p3n/osint-investigations/)
+th3cyb3rguy | Sept 2016 | [what !s 0$!nt?](https://th3cyb3rguy.com/2020/09/16/what-s-0nt/)


### PR DESCRIPTION
First, put them in new groups of Contestant Writeups, Judge Writeups, and OSINT writeups that did not really mention the TraceLabs CTF (this last group might spin off into its own page)
Second, added a date field.  This helps with repeat authors, to make sure we are getting their latest stuff.
Third, added this new content.